### PR TITLE
Fixed bug due to single input key

### DIFF
--- a/dagster_composable_graphs/jobs.py
+++ b/dagster_composable_graphs/jobs.py
@@ -29,9 +29,15 @@ def input_op_builder(name: str, static_value: Dict[str, Any]) -> dagster.OpDefin
         The generated dagster `OpDefinition`.
     """
 
+    op_outs = {k: dagster.Out(type(v)) for k, v in static_value.items()}
+
+    if len(op_outs) == 1:
+        # A dummy output is added so that the output of this op is always a dictionary.
+        op_outs |= {"dummy_value": dagster.Out(dagster.Nothing)}
+
     @dagster.op(
         name=to_snake_case(name),
-        out={k: dagster.Out(type(v)) for k, v in static_value.items()},
+        out=op_outs,
         config_schema={
             k: dagster.Field(type(v), default_value=v, is_required=False)
             for k, v in static_value.items()

--- a/tests/data/test_single_input.yaml
+++ b/tests/data/test_single_input.yaml
@@ -1,0 +1,13 @@
+apiVersion: truevoid.dev/v1alpha1
+kind: ComposableGraph
+metadata:
+  name: test-single-input
+spec:
+  inputs:
+    x: 5
+  operations:
+    - name: multiply
+      function: tests.package.graphs.multiply
+  dependencies:
+    - name: multiply
+      inputs: [x, x]

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -33,3 +33,13 @@ def test_multiple_outputs() -> None:
     execution = job.execute_in_process()
 
     assert execution.output_for_node("multiply") == 35  # noqa: PLR2004
+
+
+def test_single_input() -> None:
+    """Tests creation of a job with a single input."""
+
+    job = compose_job(load_graph_def_from_yaml(data_path / "test_single_input.yaml"))
+
+    execution = job.execute_in_process()
+
+    assert execution.output_for_node("multiply") == 25  # noqa: PLR2004


### PR DESCRIPTION
The issue occurs because dagster ops with a single output return the value as-is, while multiple outputs return a dictionary.